### PR TITLE
Assign Dependabot PRs to robinpellegrims

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
     labels:
       - "dependencies"
       - "npm"
+    assignees:
+      - "robinpellegrims"
     commit-message:
       prefix: "deps"
       prefix-development: "deps-dev"


### PR DESCRIPTION
## Summary
- Configure Dependabot to assign npm dependency update PRs to `robinpellegrims`
- Keep existing dependency labels and commit message prefixes unchanged

## Testing
- Not run (not requested)